### PR TITLE
Generate simple bulk queries

### DIFF
--- a/src/bulkQueries.ts
+++ b/src/bulkQueries.ts
@@ -1,0 +1,92 @@
+import fs from 'fs/promises';
+import * as path from 'path';
+import { Calculator, DRCalculationOutput } from 'fqm-execution';
+
+/**
+ * Loads file from cli input to calculate bulkQueries from the file
+ */
+export async function cliBulkQueries(filePath: string) {
+  // Read in bundle
+  let data: string;
+  try {
+    data = await fs.readFile(path.resolve(filePath), 'utf8');
+  } catch (err) {
+    console.error('Error reading the bundle: ', err);
+    return;
+  }
+
+  const bundle = JSON.parse(data) as fhir4.Bundle;
+  const queries = await bulkQueries(bundle);
+  console.log(JSON.stringify(queries));
+}
+
+/**
+ * Generates a
+ */
+export async function bulkQueries(bundle: fhir4.Bundle) {
+  // simple approach...
+  // If there's a codeFilter with a direct code, create a typeFilter for that code
+  // If the codeFilter doesn't have a code (valueset or some other specification), create a generic _type query instead
+  // This _type query should supercede all other potential narrowing that's found on that resource
+  // If we can narrow:
+  // Within the same DR codeFilter list, typeFilters should be ANDed (i.e. _typeFilter=A,B)
+  // Across different DR's, typeFilters should be ORd (i.e.  _typeFilter=A&_typeFilter=B)
+  // Make sure to also include a _type query for all resource types needed
+
+  const dataRequirements: DRCalculationOutput = await Calculator.calculateDataRequirements(bundle);
+
+  // // Test
+  // const dataRequirements = {results: {
+  //   dataRequirement:
+  //   [{
+  //     type: "Observation",
+  //     codeFilter: [
+  //         {
+  //             path: "code",
+  //             code: [
+  //                 {
+  //                     system: "http://loinc.org",
+  //                     display: "Hospice care [Minimum Data Set]",
+  //                     code: "45755-6"
+  //                 }
+  //             ]
+  //         }
+  //     ]
+  // }
+  // ]}}; // -> _typeFilter=Observation%3Fcode%3D45755-6&_type=Observation
+
+  // create record resourcetype => [] of valid typeFilter query strings that will be &-ed as ORs
+  const typeFilters: Record<string, string[] | undefined> = {};
+  dataRequirements.results.dataRequirement?.forEach(dr => {
+    //empty array is general _type query that overrides a more specific _typeFilter
+    if (typeFilters[dr.type]?.length === 0) return;
+
+    //any codeFilter that's non-coded or no-path or any contained codings have no code -> results in a general _type query
+    if (dr.codeFilter?.find(cf => !cf.code || !cf.path || cf.code.find(coding => !coding.code))) {
+      typeFilters[dr.type] = [];
+      return;
+    }
+    //all codefilters have a path and proper code and can be added to our typefilter array
+    const fhirQueries = dr.codeFilter?.map(cf => `${cf.path}=${cf.code?.map(coding => coding.code).join(',')}`); // potential multiple codes are comma-separated to be OR'd for this path
+    const tfStr = `${dr.type}?${fhirQueries?.join('&')}`; //Example value: 'Procedure?code=1,2&category=3,4'
+    if (typeFilters[dr.type]) {
+      typeFilters[dr.type]?.push(tfStr);
+    } else {
+      typeFilters[dr.type] = [tfStr];
+    }
+  });
+
+  //collate the types and typeFilters into the full url-encoded string that will come after our "$export?"
+  // QUESTION: This encodes the comma separating the code values (I assume that is correct, but we don't seem to support it in our server)
+  const typeQuery = `_type=${Object.keys(typeFilters).join(',')}`; // Example value: _type=Procedure,Encounter
+  const typeFilterQueries = Object.keys(typeFilters)
+    .map(resourceType => {
+      // array of all typefilters for this resource type
+      const bulkQueryArr = typeFilters[resourceType]?.map(tf => `_typeFilter=${encodeURIComponent(tf)}`);
+      // join to create params for a single resource
+      // Example value: _typeFilter=Procedure%3Fcode%3D1%2C2%26category%3D3%2C4)&_typeFilter=Procedure%3Fcode%3D5
+      return bulkQueryArr?.join('&') ?? '';
+    })
+    .filter(query => query !== '');
+  return typeFilterQueries.concat(typeQuery).join('&'); // join all non-empty resources with the type query
+}

--- a/src/bulkQueries.ts
+++ b/src/bulkQueries.ts
@@ -21,7 +21,7 @@ export async function cliBulkQueries(filePath: string) {
 }
 
 /**
- * Generates a
+ * Generates the queries that would come after a bulk "$export?""
  */
 export async function bulkQueries(bundle: fhir4.Bundle) {
   // simple approach...
@@ -34,26 +34,6 @@ export async function bulkQueries(bundle: fhir4.Bundle) {
   // Make sure to also include a _type query for all resource types needed
 
   const dataRequirements: DRCalculationOutput = await Calculator.calculateDataRequirements(bundle);
-
-  // // Test
-  // const dataRequirements = {results: {
-  //   dataRequirement:
-  //   [{
-  //     type: "Observation",
-  //     codeFilter: [
-  //         {
-  //             path: "code",
-  //             code: [
-  //                 {
-  //                     system: "http://loinc.org",
-  //                     display: "Hospice care [Minimum Data Set]",
-  //                     code: "45755-6"
-  //                 }
-  //             ]
-  //         }
-  //     ]
-  // }
-  // ]}}; // -> _typeFilter=Observation%3Fcode%3D45755-6&_type=Observation
 
   // create record resourcetype => [] of valid typeFilter query strings that will be &-ed as ORs
   const typeFilters: Record<string, string[] | undefined> = {};
@@ -76,8 +56,7 @@ export async function bulkQueries(bundle: fhir4.Bundle) {
     }
   });
 
-  //collate the types and typeFilters into the full url-encoded string that will come after our "$export?"
-  // QUESTION: This encodes the comma separating the code values (I assume that is correct, but we don't seem to support it in our server)
+  //collate the types and typeFilters into the full string that will come after our "$export?"
   const typeQuery = `_type=${Object.keys(typeFilters).join(',')}`; // Example value: _type=Procedure,Encounter
   const typeFilterQueries = Object.keys(typeFilters)
     .map(resourceType => {

--- a/src/bulkQueries.ts
+++ b/src/bulkQueries.ts
@@ -42,7 +42,7 @@ export async function bulkQueries(bundle: fhir4.Bundle) {
     if (typeFilters[dr.type]?.length === 0) return;
 
     //any codeFilter that's non-coded or no-path or any contained codings have no code -> results in a general _type query
-    if (dr.codeFilter?.find(cf => !cf.code || !cf.path || cf.code.find(coding => !coding.code))) {
+    if (dr.codeFilter?.some(cf => !cf.code || !cf.path || cf.code.some(coding => !coding.code))) {
       typeFilters[dr.type] = [];
       return;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #! node
 import { Command } from 'commander';
 import { cliDataRequirements } from './dataRequirements';
+import { cliBulkQueries } from './bulkQueries';
 
 const program = new Command();
 program.name('fqm-bulk-utils').description('FQM Bulk Utils');
@@ -10,5 +11,11 @@ program
   .argument('<measureBundle>', 'FHIR Measure Bundle path')
   .description('outputs data requirements for the passed measure bundle')
   .action(cliDataRequirements);
+
+program
+  .command('bulk-queries')
+  .argument('<measureBundle>', 'FHIR Measure Bundle path')
+  .description("outputs bulk queries based on the passed measure's data requirements")
+  .action(cliBulkQueries);
 
 program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { dataRequirements } from './dataRequirements';
+export { bulkQueries } from './bulkQueries';


### PR DESCRIPTION
# Summary
Adds bulk-queries cli and library function

## New Behavior
Can run bulk-queries command, which takes in a measure bundle path, loads the bundle, calculates the data requirements, and creates a bulk query string as it would appear after the `$export?` operation.

## Code Changes
- Add bulkQueries.ts with file-based and function based bulkQueries functions
- Adds cli configuration and library export for bulk queries

# Testing Guidance
- `npm install`
- `npm run build`
- `npm run cli bulk-queries <bath to measure bundle>` (should print dr to console)
- If there are no simple enough data requirements, the result may just be a `_type` query. The 2024 ALARACTOQR measure has a simple enough observation data requirement to also build a `_typeFilter` query ala:

`npm run cli bulk-queries ../bundles/ecqm-content-qicore-2024/bundles/measure/ALARACTOQRFHIR/ALARACTOQRFHIR-bundle.json` ... results in "_typeFilter=Observation%3Fcode%3D96914-7&_type=Observation,Encounter,Coverage"

## Outstanding questions:

1. Using `_typeFilter=Observation%3Fcode%3D96914-7` as an example... this query or queries like it does not result in a successful query against our server. If we have an Observation with
```
"code" : {
        "coding" : [
            {
                "system" : "http://snomed.info/sct",
                "version" : "2017.09.20AA",
                "code" : "469860004"
            }
        ]
    },

```
in our db and run `http://localhost:3000/Patient/$export?_typeFilter=Observation%3Fcode%3D469860004&_type=Observation` against our server, we do not successfully export that Observation from our server. I think our server is matching on the full value of the object at the `code` path. However, my instinct is that this *should* be the correct (url-encoded) way to express the FHIR query on Observation. [Bulk Access](https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/export.html#_typefilter-query-parameter) states "The value of the _typeFilter parameter is a FHIR REST API query".
 FHIR [search](https://hl7.org/fhir/R4/search.html#token) indicates `[parameter]=[code]: the value of [code] matches a Coding.code`. Is this a shortcoming of our server's implementation of _typeFilter?
 
 2. Let's say we have a similar case but instead of one code, we're matching on two potential codes for Observation. Our full query string would be `http://localhost:3000/Patient/$export?_typeFilter=Observation%3Fcode%3D469860004%2C162239000&_type=Observation` where `162239000` is the code for another Observation on our server and `%2C` is the url encoding of a comma. However, when we send this query to our server, we get 

`The following resourceTypes are not supported for _typeFilter param for $export: 162239000.`
(and the same if we just directly use a `,` instead of `%2C`). I'm currently assuming that encoding the comma is correct, but it seems our server can't differentiate that the `%2C` is not separating into a new top level parameter input to _typeFilter. Is this another server shortcoming for our implementation of _typeFilter?
