### PR TITLE
Conditional Ipp group

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { Command } from 'commander';
 import { cliDataRequirements } from './dataRequirements';
 import { cliBulkQueries } from './bulkQueries';
+import { cliGroup } from './group';
 
 const program = new Command();
 program.name('fqm-bulk-utils').description('FQM Bulk Utils');
@@ -17,5 +18,11 @@ program
   .argument('<measureBundle>', 'FHIR Measure Bundle path')
   .description("outputs bulk queries based on the passed measure's data requirements")
   .action(cliBulkQueries);
+
+program
+  .command('group')
+  .argument('<measureBundle>', 'FHIR Measure Bundle path')
+  .description("outputs a conditional group based on the passed measure's IPP definition")
+  .action(cliGroup);
 
 program.parse();

--- a/src/group.ts
+++ b/src/group.ts
@@ -56,7 +56,7 @@ export async function group(bundle: fhir4.Bundle): Promise<fhir4.Group> {
   // from https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/Group-BulkCohortGroupExample.json.html
  
   // new expression for each retrieve
-  const expresionArr = output.results.map(dtq => {
+  const expressionArr = output.results.map(dtq => {
     const queryList: string[] = [];
     if (dtq.path) {
       if (dtq.valueSet) {
@@ -78,7 +78,7 @@ export async function group(bundle: fhir4.Bundle): Promise<fhir4.Group> {
   });
 
   // format as modifier extensions
-  const modifierArr: fhir4.Extension[] = expresionArr.map(exp => {
+  const modifierArr: fhir4.Extension[] = expressionArr.map(exp => {
     return {
       url: 'http://hl7.org/fhir/uv/bulkdata/StructureDefinition/member-filter',
       valueExpression: {
@@ -159,6 +159,7 @@ function queriesForFilter(filter: AnyFilter, dataType: string): string[] {
   }
 }
 
+// Generates an array of fhir query strings for a passed valueFilter
 function valueQueries(filter: ValueFilter, dataType: string): string[] {
   const param = ExpressionSearchMap[`${dataType}.${filter.attribute}`];
   if (!param) return []; //not a searchable expression

--- a/src/group.ts
+++ b/src/group.ts
@@ -54,7 +54,7 @@ export async function group(bundle: fhir4.Bundle): Promise<fhir4.Group> {
   const output = await Calculator.calculateQueryInfo(bundle, { focusedStatement: expression });
   // example expression: 'Condition?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item&clinical-status=http://terminology.hl7.org/CodeSystem/condition-clinical|active&code=http://hl7.org/fhir/sid/icd-10-cm|E11.9'
   // from https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/Group-BulkCohortGroupExample.json.html
- 
+
   // new expression for each retrieve
   const expressionArr = output.results.map(dtq => {
     const queryList: string[] = [];
@@ -127,7 +127,6 @@ function queriesForFilter(filter: AnyFilter, dataType: string): string[] {
       if (!param) return []; //not a searchable expression
       // eslint-disable-next-line no-case-declarations
       const durationQueries = [];
-      typedFilter.valuePeriod.start;
       if (typedFilter.valuePeriod.start) {
         durationQueries.push(`${param}=gt${typedFilter.valuePeriod.start}`);
       }
@@ -194,11 +193,7 @@ function valueQueries(filter: ValueFilter, dataType: string): string[] {
   }
 
   // translate to a quantity to create a query
-  if (
-    filter.valueRatio !== undefined &&
-    filter.valueRatio.numerator?.value !== undefined &&
-    filter.valueRatio.denominator?.value !== undefined
-  ) {
+  if (filter.valueRatio?.numerator?.value !== undefined && filter.valueRatio.denominator?.value !== undefined) {
     // make sure numerator and denominator are comparable
     const numeratorSystemStr =
       filter.valueRatio.numerator.system !== undefined ? `|${filter.valueRatio.numerator.system}` : '';

--- a/src/group.ts
+++ b/src/group.ts
@@ -1,0 +1,239 @@
+import fs from 'fs/promises';
+import * as path from 'path';
+import { Calculator } from 'fqm-execution';
+import {
+  AndFilter,
+  AnyFilter,
+  DuringFilter,
+  EqualsFilter,
+  InFilter,
+  IsNullFilter,
+  NotNullFilter,
+  ValueFilter
+} from 'fqm-execution/build/types/QueryFilterTypes';
+
+/**
+ * Loads file from cli input to calculate group from the file
+ */
+export async function cliGroup(filePath: string) {
+  // Read in bundle
+  let data: string;
+  try {
+    data = await fs.readFile(path.resolve(filePath), 'utf8');
+  } catch (err) {
+    console.error('Error reading the bundle: ', err);
+    return;
+  }
+
+  const bundle = JSON.parse(data) as fhir4.Bundle;
+  const queries = await group(bundle);
+  console.log(JSON.stringify(queries));
+}
+
+/**
+ * Generates a conditional group for the passed bundle, based on the IPP
+ * NOTE: this approach does not work for negation (i.e. without), which may not be expressible for condition groups
+ */
+export async function group(bundle: fhir4.Bundle): Promise<fhir4.Group> {
+  // use measure to define IPP
+  // NOTE: Only uses the first measure group for now!
+  const measure = bundle.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource as
+    | fhir4.Measure
+    | undefined;
+
+  if (!measure?.group?.length || measure.group.length < 1) {
+    // TODO: make errors better
+    throw Error('measure does not define any groups');
+  }
+  const ipp = measure.group[0].population?.find(p => p.code?.coding?.some(c => c.code === 'initial-population'));
+  const expression = ipp?.criteria.expression;
+  if (!expression) {
+    throw Error('measure does not define an IPP expression');
+  }
+
+  const output = await Calculator.calculateQueryInfo(bundle, { focusedStatement: expression });
+  // example expression: 'Condition?category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item&clinical-status=http://terminology.hl7.org/CodeSystem/condition-clinical|active&code=http://hl7.org/fhir/sid/icd-10-cm|E11.9'
+  // new expression for each retrieve
+  const expresionArr = output.results.map(dtq => {
+    const queryList: string[] = [];
+    if (dtq.path) {
+      if (dtq.valueSet) {
+        queryList.push(`${dtq.path}:in=${dtq.valueSet}`);
+      }
+      // TODO: can both valueSet and code exist? (I don't think so... but double check)
+      if (dtq.code) {
+        queryList.push(`${dtq.path}=${dtq.code.system}|${dtq.code.code}`);
+      }
+    }
+    if (dtq.queryInfo?.filter) {
+      queryList.push(...queriesForFilter(dtq.queryInfo.filter));
+    }
+    const baseQuery = `${dtq.dataType}`;
+    if (queryList.length === 0) {
+      return baseQuery;
+    }
+    return `${baseQuery}?${queryList.join('&')}`;
+  });
+
+  // format as modifier extensions
+  const modifierArr: fhir4.Extension[] = expresionArr.map(exp => {
+    return {
+      url: 'http://hl7.org/fhir/uv/bulkdata/StructureDefinition/member-filter',
+      valueExpression: {
+        language: 'application/x-fhir-query',
+        expression: exp
+      }
+    };
+  });
+
+  //format as group
+  const group: fhir4.Group = {
+    resourceType: 'Group',
+    actual: false,
+    name: `IPP-${measure.name}`,
+    type: 'person',
+    modifierExtension: modifierArr
+  };
+
+  return group;
+}
+
+// Generates an array of fhir query strings that correspond with the passed filter and all children
+function queriesForFilter(filter: AnyFilter): string[] {
+  // how do we even know we're dealing with a search parameter?
+  // TODO: (fhir-spec-tools needs added functionality) **path expression needs to be converted to the search parameter
+
+  let typedFilter;
+  switch (filter.type) {
+    case 'and':
+      return (filter as AndFilter).children.flatMap(c => queriesForFilter(c));
+    case 'in':
+      typedFilter = filter as InFilter;
+      if (typedFilter.valueCodingList) {
+        // technically the code could be undefined, but eh
+        return [`${typedFilter.attribute}=${typedFilter.valueCodingList.map(c => c.code).join(',')}`];
+      }
+      if (typedFilter.valueList) {
+        return [`${typedFilter.attribute}=${typedFilter.valueList.join(',')}`];
+      }
+      return [];
+    case 'during':
+      // CQL spec indicates synonymous with IncludedIn: if the first operand is completely included in the second
+      // assume exclusive for dates?
+      typedFilter = filter as DuringFilter;
+      // eslint-disable-next-line no-case-declarations
+      const durationQueries = [];
+      typedFilter.valuePeriod.start;
+      if (typedFilter.valuePeriod.start) {
+        durationQueries.push(`${typedFilter.attribute}=gt${typedFilter.valuePeriod.start}`);
+      }
+      if (typedFilter.valuePeriod.end) {
+        durationQueries.push(`${typedFilter.attribute}=lt${typedFilter.valuePeriod.end}`);
+      }
+      return durationQueries;
+    case 'isnull':
+      return [`${(filter as IsNullFilter).attribute}:missing=true`];
+    case 'notnull':
+      return [`${(filter as NotNullFilter).attribute}:missing=false`];
+    case 'equals':
+      typedFilter = filter as EqualsFilter;
+      return [`${typedFilter.attribute}=${typedFilter.value}`];
+    case 'value':
+      return valueQueries(filter as ValueFilter);
+    default:
+      //or, truth, unknown, whatever other type
+      console.warn(`Ignoring "${filter.type}" filter`);
+      return [];
+  }
+}
+
+function valueQueries(filter: ValueFilter): string[] {
+  // Search prefixes are available for numbers, dates, and quantities https://hl7.org/fhir/R4/search.html#prefix
+  // For boolean and string, only allow equal
+  if (filter.valueBoolean !== undefined) {
+    if (filter.comparator === 'eq') {
+      return [`${filter.attribute}=${filter.valueBoolean}`];
+    }
+    return [];
+  }
+  if (filter.valueString !== undefined) {
+    if (filter.comparator === 'eq') {
+      return [`${filter.attribute}=${filter.valueString}`];
+    }
+    return [];
+  }
+  // sa (starts-after) and eb (ends-before) are not used with integer values
+  if (filter.valueInteger !== undefined) {
+    if (filter.comparator === 'sa' || filter.comparator === 'eb') {
+      return [];
+    } else {
+      return [`${filter.attribute}=${filter.comparator}${filter.valueString}`];
+    }
+  }
+  // quantity [parameter]=[prefix][number]|[system]|[code]
+  if (filter.valueQuantity !== undefined && filter.valueQuantity.value !== undefined) {
+    const systemStr = filter.valueQuantity.system !== undefined ? `|${filter.valueQuantity.system}` : '';
+    const codeStr = filter.valueQuantity.code !== undefined ? `|${filter.valueQuantity.code}` : '';
+    return [`${filter.attribute}=${filter.comparator}${filter.valueQuantity.value}${systemStr}${codeStr}`];
+  }
+
+  // translate to a quantity to create a query
+  if (
+    filter.valueRatio !== undefined &&
+    filter.valueRatio.numerator?.value !== undefined &&
+    filter.valueRatio.denominator?.value !== undefined
+  ) {
+    // make sure numerator and denominator are comparable
+    const numeratorSystemStr =
+      filter.valueRatio.numerator.system !== undefined ? `|${filter.valueRatio.numerator.system}` : '';
+    const denominatorSystemStr =
+      filter.valueRatio.denominator.system !== undefined ? `|${filter.valueRatio.denominator.system}` : '';
+    const numeratorCodeStr =
+      filter.valueRatio.numerator.code !== undefined ? `|${filter.valueRatio.numerator.code}` : '';
+    const denominatorCodeStr =
+      filter.valueRatio.denominator.code !== undefined ? `|${filter.valueRatio.denominator.code}` : '';
+    if (numeratorSystemStr === denominatorSystemStr && numeratorCodeStr === denominatorCodeStr) {
+      const ratioNumber = filter.valueRatio.numerator.value / filter.valueRatio.denominator.value;
+      return [`${filter.attribute}=${filter.comparator}${ratioNumber}${numeratorSystemStr}${numeratorCodeStr}`];
+    }
+    return [];
+  }
+
+  // Unsure of how to express an explicit range in the query
+  // Instead, use table at https://hl7.org/fhir/R4/search.html#prefix
+  // target is the thing you're looking for while searching
+  // and search value is the value passed to the query parameter
+  if (filter.valueRange !== undefined) {
+    const rangeQueries = [];
+    if (filter.comparator === 'eq') {
+      // the range of the search value fully contains the range of the target value
+      // assume inclusive for quantities?
+      if (filter.valueRange.low !== undefined) {
+        const systemStr = filter.valueRange.low.system !== undefined ? `|${filter.valueRange.low.system}` : '';
+        const codeStr = filter.valueRange.low.code !== undefined ? `|${filter.valueRange.low.code}` : '';
+        rangeQueries.push(`${filter.attribute}=ge${filter.valueRange.low}${systemStr}${codeStr}`);
+      }
+      if (filter.valueRange.high !== undefined) {
+        const systemStr = filter.valueRange.high.system !== undefined ? `|${filter.valueRange.high.system}` : '';
+        const codeStr = filter.valueRange.high.code !== undefined ? `|${filter.valueRange.high.code}` : '';
+        rangeQueries.push(`${filter.attribute}=le${filter.valueRange.high}${systemStr}${codeStr}`);
+      }
+    } else if (filter.comparator === 'gt') {
+      // the range above the search value intersects (i.e. overlaps) with the range of the target value
+      // TODO: figure out how to do the rest of these... what does "the range above the search value" mean when the search value is a range (above the low or above the high?)
+    } else if (filter.comparator === 'lt') {
+      // the range below the search value intersects (i.e. overlaps) with the range of the target value
+    } else if (filter.comparator === 'ge') {
+      // the range above the search value intersects (i.e. overlaps) with the range of the target value, or the range of the search value fully contains the range of the target value
+    } else if (filter.comparator === 'le') {
+      // the range below the search value intersects (i.e. overlaps) with the range of the target value or the range of the search value fully contains the range of the target value
+    } else if (filter.comparator === 'sa') {
+      // the range of the search value does not overlap with the range of the target value, and the range above the search value contains the range of the target value
+    } else if (filter.comparator === 'eb') {
+      // the range of the search value does overlap not with the range of the target value, and the range below the search value contains the range of the target value
+    }
+    return rangeQueries;
+  }
+
+  return [];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { dataRequirements } from './dataRequirements';
 export { bulkQueries } from './bulkQueries';
+export { group } from './group';


### PR DESCRIPTION
Note: This is branched off of bulk-queries for convenience, but I assume that will get merged first? They're pretty independent functionality. Basically everything of interest in this PR is in `group.ts`

There's still a couple of minor TODOs in the `group.ts` file, the biggest of which is handling ValueFilters with Ranges (which seems maybe doable, but I haven't found the right guidance yet). And there's some caveats like it won't work for negations like `without` since it's creating a query for every retrieve (but how would we even handle specifying that query anyway?).


# Summary
Creates both cli and library functionality to create a conditional group based on the CQL logic for the IPP of the passed measure bundle. This is done by creating  fhirquery expressions for each of the retrieves calculated by the `calculateQueryInfo` function in `fqm-execution`.

## New Behavior
Can run group command, which takes in a measure bundle path, loads the bundle, calculates the group information, and creates a conditional group object as could be posted to an export server (to test $export-ing conditional groups).

## Code Changes
- Add `group` command to cli.ts
- Export `group` in index.ts
- New `group.ts` has cli and library function, builds queries for a conditional group based on the filters in the query information generated from a measure's initial population

# Testing Guidance
- This is dependent on two other repository branches
- Pull down https://github.com/projecttacoma/fqm-execution/tree/enhanced-calcqi
- Pull down https://github.com/projecttacoma/fhir-spec-tools/tree/search-param-expressions
- `npm install ../fhir-spec-tools` (or wherever your repo is)
- `npm install ../fqm-execution` (or wherever your repo is)
- `npm run build`
- `npm run cli group <path to measure bundle>` (should print group to console)